### PR TITLE
Require at least ruby 2.4

### DIFF
--- a/dctl_rb.gemspec
+++ b/dctl_rb.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = ["dctl"]
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = ">= 2.4", "< 3"
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug", "~> 9.1"


### PR DESCRIPTION
Other versions are not tested so it seems not cool to say we support
them