### PR TITLE
Allow specifying negative version numbers to tag-for

### DIFF
--- a/lib/dctl/main.rb
+++ b/lib/dctl/main.rb
@@ -21,6 +21,7 @@ module Dctl
 
       tag = "#{org}/#{project}-#{env}-#{image}"
       if !version.nil?
+        version = version.to_i
         tag +=
           if version.negative?
             current_version = current_version_for_image(image)

--- a/lib/dctl/main.rb
+++ b/lib/dctl/main.rb
@@ -20,7 +20,15 @@ module Dctl
       project   = settings.project
 
       tag = "#{org}/#{project}-#{env}-#{image}"
-      tag += ":#{version}" if !version.nil?
+      if !version.nil?
+        tag +=
+          if version.negative?
+            current_version = current_version_for_image(image)
+            ":#{current_version + version}"
+          else
+            ":#{version}"
+          end
+      end
 
       tag
     end

--- a/spec/dctl/main_spec.rb
+++ b/spec/dctl/main_spec.rb
@@ -77,6 +77,25 @@ RSpec.describe Dctl::Main do
         )
       end
     end
+
+    it "doesn't mind if version numbers are strings" do
+      config = <<~CONFIG
+        org: jutonz
+        project: dctl_rb
+      CONFIG
+
+      with_config(config) do |config_path|
+        dctl = Dctl::Main.new(config: config_path)
+        service = "app"
+
+        expect(dctl).to receive(:current_version_for_image).with(service)
+          .and_return(10)
+
+        expect(dctl.image_tag(service, version: "-1")).to eq(
+          "jutonz/dctl_rb-dev-app:9"
+        )
+      end
+    end
   end
 end
 

--- a/spec/dctl/main_spec.rb
+++ b/spec/dctl/main_spec.rb
@@ -40,6 +40,44 @@ RSpec.describe Dctl::Main do
       end
     end
   end
+
+  describe "#image_tag" do
+    it "returns a tag" do
+      config = <<~CONFIG
+        org: jutonz
+        project: dctl_rb
+      CONFIG
+
+      with_config(config) do |config_path|
+        dctl = Dctl::Main.new(config: config_path)
+        service = "app"
+
+        expect(dctl).to receive(:current_version_for_image).with(service)
+          .and_return(10)
+
+        expect(dctl.image_tag(service)).to eq "jutonz/dctl_rb-dev-app:10"
+      end
+    end
+
+    it "allows specifying negative version numbers" do
+      config = <<~CONFIG
+        org: jutonz
+        project: dctl_rb
+      CONFIG
+
+      with_config(config) do |config_path|
+        dctl = Dctl::Main.new(config: config_path)
+        service = "app"
+
+        expect(dctl).to receive(:current_version_for_image).with(service)
+          .and_return(10)
+
+        expect(dctl.image_tag(service, version: -1)).to eq(
+          "jutonz/dctl_rb-dev-app:9"
+        )
+      end
+    end
+  end
 end
 
 def with_config(config_str, &block)


### PR DESCRIPTION
If `dctl tag-for app` returns `jutonz/dctl_rb-dev-app:10`, `dctl tag-for app --version=-1` will return `jutonz/dctl_rb-dev-app:9`.

Note that this implies only positive version numbers, but I think this is okay.